### PR TITLE
Add PostgreSQL for Heroku

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,11 +3,18 @@ source "https://rubygems.org"
 gem "sinatra", "~> 1.4.7"
 gem "activerecord", "~> 5.0.1"
 gem "sinatra-activerecord", "~> 2.0.11"
-gem "sqlite3", "~> 1.3.12"
 gem 'rake'
 gem 'racksh'
 gem 'bcrypt'
 gem 'rerun'
+
+group :production do
+  gem "pg", "~> 0.20.0"
+end
+
+group :development, :test do
+  gem "sqlite3", "~> 1.3.12"
+end
 
 group :test do
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,6 +22,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     minitest (5.10.1)
+    pg (0.20.0)
     rack (1.6.5)
     rack-protection (1.5.3)
       rack
@@ -56,6 +57,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord (~> 5.0.1)
   bcrypt
+  pg (~> 0.20.0)
   rack-test
   racksh
   rake
@@ -65,4 +67,4 @@ DEPENDENCIES
   sqlite3 (~> 1.3.12)
 
 BUNDLED WITH
-   1.13.1
+   1.14.6

--- a/environment.rb
+++ b/environment.rb
@@ -10,3 +10,16 @@ end
 configure :test do
   set :database, 'sqlite3:db/test.sqlite'
 end
+
+configure :production do
+  db = URI.parse(ENV['DATABASE_URL'] || 'postgres:///localhost/db')
+
+  ActiveRecord::Base.establish_connection(
+    :adapter  => db.scheme == 'postgres' ? 'postgresql' : db.scheme,
+    :host     => db.host,
+    :username => db.user,
+    :password => db.password,
+    :database => db.path[1..-1],
+    :encoding => 'utf8'
+  )
+end


### PR DESCRIPTION
This commit adds PostgreSQL as the database server used for production. This allows the app to be deployed to Heroku, which doesn’t support SQLite.